### PR TITLE
feat: add User-Agent header for backend metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## 0.1.1 (Unreleased)
+
+## Improvements
+* Add `User-Agent` header for Lacework API backend metrics
+
 # 0.1.0 (June 02, 2020)
 
 ## New Resources

--- a/lacework/version.go
+++ b/lacework/version.go
@@ -1,0 +1,5 @@
+package lacework
+
+// TODO @afiune to figure out how to update our version in Travis
+// for now, we will do it manually until we automate it
+const version = "0.1.1"


### PR DESCRIPTION
This change adds the `User-Agent` header for the Lacework Terraform
Provider to `Terraform/{VERSION}` for every request.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>