### PR TITLE
fix(gcp): suppress private key diff to avoid updates

### DIFF
--- a/lacework/resource_lacework_integration_gcp_at.go
+++ b/lacework/resource_lacework_integration_gcp_at.go
@@ -57,6 +57,11 @@ func resourceLaceworkIntegrationGcpAt() *schema.Resource {
 							Type:      schema.TypeString,
 							Required:  true,
 							Sensitive: true,
+							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+								// @afiune we can't compare this element since our API, for security reasons,
+								// does NOT return the private key configured in the Lacework server
+								return true
+							},
 						},
 					},
 				},

--- a/lacework/resource_lacework_integration_gcp_cfg.go
+++ b/lacework/resource_lacework_integration_gcp_cfg.go
@@ -57,6 +57,11 @@ func resourceLaceworkIntegrationGcpCfg() *schema.Resource {
 							Type:      schema.TypeString,
 							Required:  true,
 							Sensitive: true,
+							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+								// @afiune we can't compare this element since our API, for security reasons,
+								// does NOT return the private key configured in the Lacework server
+								return true
+							},
 						},
 					},
 				},


### PR DESCRIPTION
When you run terraform apply after creating a gcp resource, we were
trying to update the `private_key` when it is a sensitive element and
the Lacework server, for security reasons, doesn't return that secret,
which means that the resource was always different.

We are adding a suppression to avoid updating the resource.

Closes https://github.com/terraform-providers/terraform-provider-lacework/issues/4

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>