### PR TITLE
fix(gcp): detect a change of credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 0.3.0 (Unreleased)
+## 0.2.1 (Unreleased)
+
+## Bug Fixes
+* fix(gcp): detect a change of credentials [#14](https://github.com/terraform-providers/terraform-provider-lacework/pull/14)
+
 ## 0.2.0 (July 23, 2020)
 
 ## Improvements

--- a/lacework/resource_lacework_integration_gcp_at.go
+++ b/lacework/resource_lacework_integration_gcp_at.go
@@ -59,7 +59,13 @@ func resourceLaceworkIntegrationGcpAt() *schema.Resource {
 							Sensitive: true,
 							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 								// @afiune we can't compare this element since our API, for security reasons,
-								// does NOT return the private key configured in the Lacework server
+								// does NOT return the private key configured in the Lacework server. So if
+								// any other element changed from the credentials then we trigger a diff
+								if d.HasChange("credentials.0.client_id") ||
+									d.HasChange("credentials.0.private_key_id") ||
+									d.HasChange("credentials.0.client_email") {
+									return false
+								}
 								return true
 							},
 						},

--- a/lacework/resource_lacework_integration_gcp_cfg.go
+++ b/lacework/resource_lacework_integration_gcp_cfg.go
@@ -59,7 +59,13 @@ func resourceLaceworkIntegrationGcpCfg() *schema.Resource {
 							Sensitive: true,
 							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 								// @afiune we can't compare this element since our API, for security reasons,
-								// does NOT return the private key configured in the Lacework server
+								// does NOT return the private key configured in the Lacework server. So if
+								// any other element changed from the credentials then we trigger a diff
+								if d.HasChange("credentials.0.client_id") ||
+									d.HasChange("credentials.0.private_key_id") ||
+									d.HasChange("credentials.0.client_email") {
+									return false
+								}
 								return true
 							},
 						},

--- a/lacework/version.go
+++ b/lacework/version.go
@@ -2,4 +2,4 @@ package lacework
 
 // TODO @afiune to figure out how to update our version in Travis
 // for now, we will do it manually until we automate it
-const version = "0.2.0"
+const version = "0.2.1"


### PR DESCRIPTION
Previously, we tried to fix an issue by avoiding triggering a state change if the `private_key`
was different (https://github.com/terraform-providers/terraform-provider-lacework/pull/10) this suppression made it so that we never send the value to any request
and therefore, having consistent `500 Schema Validation` errors.

This change is fixing this issue by checking if there is a change in any of the "known values
that the server will return" then do NOT suppress the diff, but suppress it otherwise.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>