### PR TITLE
fix(gcp): update private_key suppression logic

### DIFF
--- a/lacework/resource_lacework_integration_gcp_at.go
+++ b/lacework/resource_lacework_integration_gcp_at.go
@@ -61,9 +61,13 @@ func resourceLaceworkIntegrationGcpAt() *schema.Resource {
 								// @afiune we can't compare this element since our API, for security reasons,
 								// does NOT return the private key configured in the Lacework server. So if
 								// any other element changed from the credentials then we trigger a diff
-								if d.HasChange("credentials.0.client_id") ||
-									d.HasChange("credentials.0.private_key_id") ||
-									d.HasChange("credentials.0.client_email") {
+								if d.HasChanges(
+									"name", "resource_level", "resource_id",
+									"subscription", "org_level", "enabled",
+									"credentials.0.client_id",
+									"credentials.0.private_key_id",
+									"credentials.0.client_email",
+								) {
 									return false
 								}
 								return true

--- a/lacework/resource_lacework_integration_gcp_cfg.go
+++ b/lacework/resource_lacework_integration_gcp_cfg.go
@@ -61,9 +61,11 @@ func resourceLaceworkIntegrationGcpCfg() *schema.Resource {
 								// @afiune we can't compare this element since our API, for security reasons,
 								// does NOT return the private key configured in the Lacework server. So if
 								// any other element changed from the credentials then we trigger a diff
-								if d.HasChange("credentials.0.client_id") ||
-									d.HasChange("credentials.0.private_key_id") ||
-									d.HasChange("credentials.0.client_email") {
+								if d.HasChanges(
+									"name", "resource_level", "resource_id", "org_level", "enabled",
+									"credentials.0.client_id", "credentials.0.private_key_id",
+									"credentials.0.client_email",
+								) {
 									return false
 								}
 								return true


### PR DESCRIPTION
We are updating the `DiffSuppressFunc` of the `private_key` element so
that we capture any change but the `private_key`. Not sure if this is
the best way to ignore one element from the resource diff, but also, use
the element on any other change.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>