### PR TITLE
feat(provider): tenant argument to manage sub-accounts

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -101,4 +101,10 @@ The following arguments are supported in the `provider` block:
   can also be sourced from the `LW_API_SECRET` environment variable, or via the configuration
   file if `profile` is specified.
 
+* `tenant` - (Optional) This is a tenant name within your Lacework account. This argument
+  allows Organization Admins to manage multiple sub-accounts with a single API key. It can
+  also be sourced from the `LW_TENANT` environment variable, or via the configuration file
+  if `profile` is specified.
+
+
 -> **Note:** To generate a set of API access keys follow [this documentation](https://support.lacework.com/hc/en-us/articles/360011403853-Generate-API-Access-Keys-and-Tokens).


### PR DESCRIPTION
This change is adding a new argument to our provider named `tenant`,
it is otional and allows Organization Admins to manage multiple
sub-accounts with a single API key. It can also be sourced from the
`LW_TENANT` environment variable, or via the configuration file if
`profile` is specified.

Example: having a single API key with Organization Admin priviledges
configured into the local Lacework CLI configuratio file at
`~/.lacework.toml`:
```toml
[default]
  account = "primary-account"
  api_key = "my-org-admin-key"
  api_secret = "my-org-admin-secret"
```

You can configure the Lacework provider to point to multipel
sub-accounts using this new argument:
```hcl
provider "lacework" {
  alias = "primary"
}

provider "lacework" {
  alias  = "subaccount1"
  tenant = "subaccount1"
}

provider "lacework" {
  alias  = "subaccount2"
  tenant = "subaccount2"
}

provider "lacework" {
  alias  = "subaccountN"
  tenant = "subaccountN"
}
```

Depends on https://github.com/lacework/go-sdk/pull/177

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>