### PR TITLE
chore(doc): fix typo in aws_cloudwatch

### DIFF
--- a/website/docs/r/alert_channel_aws_cloudwatch.html.markdown
+++ b/website/docs/r/alert_channel_aws_cloudwatch.html.markdown
@@ -5,7 +5,7 @@ description: |-
   Create an manage AWS CloudWatch Alert Channel integrations
 ---
 
-# lacework\_alert\_channel\_aws_\cloudwatch
+# lacework\_alert\_channel\_aws\_cloudwatch
 
 Configure Lacework to forward alerts to an AWS CloudWatch event bus.
 


### PR DESCRIPTION
This fixes the following typo:
![image](https://user-images.githubusercontent.com/5712253/89053123-fa930580-d313-11ea-870d-9ca2ea3deec5.png)


Signed-off-by: Salim Afiune Maya <afiune@lacework.net>