### PR TITLE
fix(azure): suppress client_secret diff to avoid updates

### DIFF
--- a/lacework/resource_lacework_integration_azure_al.go
+++ b/lacework/resource_lacework_integration_azure_al.go
@@ -52,8 +52,21 @@ func resourceLaceworkIntegrationAzureActivityLog() *schema.Resource {
 							Required: true,
 						},
 						"client_secret": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:      schema.TypeString,
+							Required:  true,
+							Sensitive: true,
+							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+								// @afiune we can't compare this element since our API, for security reasons,
+								// does NOT return the client secret configured in the Lacework server. So if
+								// any other element changed from the credentials then we trigger a diff
+								if d.HasChanges(
+									"name", "tenant_id", "org_level", "queue_url",
+									"enabled", "credentials.0.client_id",
+								) {
+									return false
+								}
+								return true
+							},
 						},
 					},
 				},

--- a/lacework/resource_lacework_integration_azure_cfg.go
+++ b/lacework/resource_lacework_integration_azure_cfg.go
@@ -49,8 +49,21 @@ func resourceLaceworkIntegrationAzureCfg() *schema.Resource {
 							Required: true,
 						},
 						"client_secret": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:      schema.TypeString,
+							Required:  true,
+							Sensitive: true,
+							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+								// @afiune we can't compare this element since our API, for security reasons,
+								// does NOT return the client secret configured in the Lacework server. So if
+								// any other element changed from the credentials then we trigger a diff
+								if d.HasChanges(
+									"name", "tenant_id", "org_level",
+									"enabled", "credentials.0.client_id",
+								) {
+									return false
+								}
+								return true
+							},
 						},
 					},
 				},


### PR DESCRIPTION
When you run terraform apply after creating a azure resource, we were
trying to update the client_secret when it is a sensitive element and
the Lacework server, for security reasons, doesn't return that secret,
which means that the resource was always different.

We are adding a suppression to avoid updating the resource.

Similar PR to https://github.com/terraform-providers/terraform-provider-lacework/pull/10 & https://github.com/terraform-providers/terraform-provider-lacework/pull/15

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>