### PR TITLE
feat: new container registry resources

### DIFF
--- a/examples/resource_lacework_integration_docker_v2/main.tf
+++ b/examples/resource_lacework_integration_docker_v2/main.tf
@@ -1,0 +1,11 @@
+provider "lacework" {}
+
+resource "lacework_integration_docker_v2" "example" {
+  name            = "My Docker V2 Registry Example"
+  registry_domain = "127.0.0.1:1234"
+  username        = "my-user"
+  password        = "a-secret-password"
+  ssl             = true
+  limit_by_tag    = "dev*"
+  limit_by_label  = "*label"
+}

--- a/examples/resource_lacework_integration_ecr/main.tf
+++ b/examples/resource_lacework_integration_ecr/main.tf
@@ -1,0 +1,12 @@
+provider "lacework" {}
+
+resource "lacework_integration_ecr" "example" {
+  name              = "ERC Example"
+  registry_domain   = "YourAWSAccount.dkr.ecr.YourRegion.amazonaws.com"
+  access_key_id     = "AWS123abcAccessKeyID"
+  secret_access_key = "AWS123abc123abcSecretAccessKey0000000000"
+  limit_by_tag      = "dev*"
+  limit_by_label    = "*label"
+  limit_by_repos    = "my-repo,other-repo"
+  limit_num_imgs    = 10
+}

--- a/examples/resource_lacework_integration_gcr/main.tf
+++ b/examples/resource_lacework_integration_gcr/main.tf
@@ -1,0 +1,16 @@
+provider "lacework" {}
+
+resource "lacework_integration_gcr" "example" {
+  name            = "GRC Example"
+  registry_domain = "gcr.io"
+  credentials {
+    client_id      = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+    private_key_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+    client_email   = "email@some-project-name.iam.gserviceaccount.com"
+    private_key    = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+  }
+  limit_by_tag   = "dev*"
+  limit_by_label = "*label"
+  limit_by_repos = "my-repo,other-repo"
+  limit_num_imgs = 10
+}

--- a/lacework/provider.go
+++ b/lacework/provider.go
@@ -57,6 +57,7 @@ func Provider() terraform.ResourceProvider {
 			"lacework_integration_azure_cfg":        resourceLaceworkIntegrationAzureCfg(),
 			"lacework_integration_azure_al":         resourceLaceworkIntegrationAzureActivityLog(),
 			"lacework_integration_docker_hub":       resourceLaceworkIntegrationDockerHub(),
+			"lacework_integration_docker_v2":        resourceLaceworkIntegrationDockerV2(),
 			"lacework_integration_gcp_cfg":          resourceLaceworkIntegrationGcpCfg(),
 			"lacework_integration_gcp_at":           resourceLaceworkIntegrationGcpAt(),
 		},

--- a/lacework/provider.go
+++ b/lacework/provider.go
@@ -58,6 +58,7 @@ func Provider() terraform.ResourceProvider {
 			"lacework_integration_azure_al":         resourceLaceworkIntegrationAzureActivityLog(),
 			"lacework_integration_docker_hub":       resourceLaceworkIntegrationDockerHub(),
 			"lacework_integration_docker_v2":        resourceLaceworkIntegrationDockerV2(),
+			"lacework_integration_ecr":              resourceLaceworkIntegrationEcr(),
 			"lacework_integration_gcp_cfg":          resourceLaceworkIntegrationGcpCfg(),
 			"lacework_integration_gcp_at":           resourceLaceworkIntegrationGcpAt(),
 			"lacework_integration_gcr":              resourceLaceworkIntegrationGcr(),

--- a/lacework/provider.go
+++ b/lacework/provider.go
@@ -60,6 +60,7 @@ func Provider() terraform.ResourceProvider {
 			"lacework_integration_docker_v2":        resourceLaceworkIntegrationDockerV2(),
 			"lacework_integration_gcp_cfg":          resourceLaceworkIntegrationGcpCfg(),
 			"lacework_integration_gcp_at":           resourceLaceworkIntegrationGcpAt(),
+			"lacework_integration_gcr":              resourceLaceworkIntegrationGcr(),
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{

--- a/lacework/resource_lacework_integration_docker_hub_test.go
+++ b/lacework/resource_lacework_integration_docker_hub_test.go
@@ -20,7 +20,7 @@ const (
 	testAccIntegrationContainerRegEnvLimitByRepos = "LIMIT_BY_REP"
 	testAccIntegrationContainerRegEnvLimitNumImg  = "LIMIT_NUM_IMG"
 	testAccIntegrationDockerHubEnvUsername        = "DOCKER_USERNAME"
-	testAccIntegrationDockerHubEnvPassword        = "PASSWORD"
+	testAccIntegrationDockerHubEnvPassword        = "DOCKER_PASSWORD"
 )
 
 func TestAccIntegrationDockerHub(t *testing.T) {
@@ -156,11 +156,11 @@ resource "%s" "%s" {
 		testAccIntegrationDockerHubResourceType,
 		testAccIntegrationDockerHubResourceName,
 		enabled,
+		os.Getenv(testAccIntegrationDockerHubEnvUsername),
+		os.Getenv(testAccIntegrationDockerHubEnvPassword),
 		os.Getenv(testAccIntegrationContainerRegEnvLimitByTag),
 		os.Getenv(testAccIntegrationContainerRegEnvLimitByLabel),
 		os.Getenv(testAccIntegrationContainerRegEnvLimitByRepos),
 		os.Getenv(testAccIntegrationContainerRegEnvLimitNumImg),
-		os.Getenv(testAccIntegrationDockerHubEnvUsername),
-		os.Getenv(testAccIntegrationDockerHubEnvPassword),
 	)
 }

--- a/lacework/resource_lacework_integration_docker_v2.go
+++ b/lacework/resource_lacework_integration_docker_v2.go
@@ -1,0 +1,229 @@
+package lacework
+
+import (
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+
+	"github.com/lacework/go-sdk/api"
+)
+
+func resourceLaceworkIntegrationDockerV2() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceLaceworkIntegrationDockerV2Create,
+		Read:   resourceLaceworkIntegrationDockerV2Read,
+		Update: resourceLaceworkIntegrationDockerV2Update,
+		Delete: resourceLaceworkIntegrationDockerV2Delete,
+
+		Importer: &schema.ResourceImporter{
+			State: importLaceworkIntegration,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"registry_domain": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"username": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"password": {
+				Type:      schema.TypeString,
+				Required:  true,
+				Sensitive: true,
+			},
+			"ssl": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"limit_by_tag": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "*",
+			},
+			"limit_by_label": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "*",
+			},
+			"intg_guid": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_or_updated_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_or_updated_by": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"type_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"org_level": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceLaceworkIntegrationDockerV2Create(d *schema.ResourceData, meta interface{}) error {
+	lacework := meta.(*api.Client)
+	data := api.NewDockerV2RegistryIntegration(d.Get("name").(string),
+		api.ContainerRegData{
+			LimitByTag:     d.Get("limit_by_tag").(string),
+			LimitByLabel:   d.Get("limit_by_label").(string),
+			RegistryDomain: d.Get("registry_domain").(string),
+			Credentials: api.ContainerRegCreds{
+				Username: d.Get("username").(string),
+				Password: d.Get("password").(string),
+				SSL:      d.Get("ssl").(bool),
+			},
+		},
+	)
+
+	if !d.Get("enabled").(bool) {
+		data.Enabled = 0
+	}
+
+	log.Printf("[INFO] Creating %s integration %s registry type with data:\n%+v\n",
+		api.ContainerRegistryIntegration.String(), api.DockerV2Registry.String(), data)
+	response, err := lacework.Integrations.CreateContainerRegistry(data)
+	if err != nil {
+		return err
+	}
+
+	for _, integration := range response.Data {
+		d.SetId(integration.IntgGuid)
+		d.Set("name", integration.Name)
+		d.Set("intg_guid", integration.IntgGuid)
+		d.Set("enabled", integration.Enabled == 1)
+		d.Set("created_or_updated_time", integration.CreatedOrUpdatedTime)
+		d.Set("created_or_updated_by", integration.CreatedOrUpdatedBy)
+		d.Set("type_name", integration.TypeName)
+		d.Set("org_level", integration.IsOrg == 1)
+
+		log.Printf("[INFO] Created %s integration %s registry type with guid: %v\n",
+			api.ContainerRegistryIntegration.String(), api.DockerV2Registry.String(), integration.IntgGuid)
+		return nil
+	}
+
+	return nil
+}
+
+func resourceLaceworkIntegrationDockerV2Read(d *schema.ResourceData, meta interface{}) error {
+	lacework := meta.(*api.Client)
+
+	log.Printf("[INFO] Reading %s integration %s registry type with guid: %v\n",
+		api.ContainerRegistryIntegration.String(), api.DockerV2Registry.String(), d.Id())
+	response, err := lacework.Integrations.GetContainerRegistry(d.Id())
+
+	if err != nil {
+		return err
+	}
+
+	for _, integration := range response.Data {
+		if integration.IntgGuid == d.Id() {
+			d.Set("name", integration.Name)
+			d.Set("intg_guid", integration.IntgGuid)
+			d.Set("enabled", integration.Enabled == 1)
+			d.Set("created_or_updated_time", integration.CreatedOrUpdatedTime)
+			d.Set("created_or_updated_by", integration.CreatedOrUpdatedBy)
+			d.Set("type_name", integration.TypeName)
+			d.Set("org_level", integration.IsOrg == 1)
+
+			d.Set("registry_domain", integration.Data.RegistryDomain)
+			d.Set("username", integration.Data.Credentials.Username)
+			d.Set("password", integration.Data.Credentials.Password)
+			d.Set("ssl", integration.Data.Credentials.SSL)
+			d.Set("limit_by_tag", integration.Data.LimitByTag)
+			d.Set("limit_by_label", integration.Data.LimitByLabel)
+
+			log.Printf("[INFO] Read %s integration %s registry type with guid: %v\n",
+				api.ContainerRegistryIntegration.String(), api.DockerV2Registry.String(), integration.IntgGuid)
+			return nil
+		}
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func resourceLaceworkIntegrationDockerV2Update(d *schema.ResourceData, meta interface{}) error {
+	lacework := meta.(*api.Client)
+	data := api.NewDockerV2RegistryIntegration(d.Get("name").(string),
+		api.ContainerRegData{
+			LimitByTag:     d.Get("limit_by_tag").(string),
+			LimitByLabel:   d.Get("limit_by_label").(string),
+			RegistryDomain: d.Get("registry_domain").(string),
+			Credentials: api.ContainerRegCreds{
+				Username: d.Get("username").(string),
+				Password: d.Get("password").(string),
+				SSL:      d.Get("ssl").(bool),
+			},
+		},
+	)
+
+	if !d.Get("enabled").(bool) {
+		data.Enabled = 0
+	}
+
+	data.IntgGuid = d.Id()
+
+	log.Printf("[INFO] Updating %s integration %s registry type with data:\n%+v\n",
+		api.ContainerRegistryIntegration.String(), api.DockerV2Registry.String(), data)
+	response, err := lacework.Integrations.UpdateContainerRegistry(data)
+	if err != nil {
+		return err
+	}
+
+	for _, integration := range response.Data {
+		if integration.IntgGuid == d.Id() {
+			d.Set("name", integration.Name)
+			d.Set("intg_guid", integration.IntgGuid)
+			d.Set("enabled", integration.Enabled == 1)
+			d.Set("created_or_updated_time", integration.CreatedOrUpdatedTime)
+			d.Set("created_or_updated_by", integration.CreatedOrUpdatedBy)
+			d.Set("type_name", integration.TypeName)
+			d.Set("org_level", integration.IsOrg == 1)
+
+			log.Printf("[INFO] Updated %s integration %s registry type with guid: %v\n",
+				api.ContainerRegistryIntegration.String(), api.DockerV2Registry.String(), d.Id())
+
+			return nil
+		}
+	}
+
+	return nil
+}
+
+func resourceLaceworkIntegrationDockerV2Delete(d *schema.ResourceData, meta interface{}) error {
+	lacework := meta.(*api.Client)
+
+	log.Printf("[INFO] Deleting %s integration %s registry type with guid: %v\n",
+		api.ContainerRegistryIntegration.String(), api.DockerV2Registry.String(), d.Id())
+
+	_, err := lacework.Integrations.Delete(d.Id())
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[INFO] Deleted %s integration %s registry type with guid: %v\n",
+		api.ContainerRegistryIntegration.String(), api.DockerV2Registry.String(), d.Id())
+
+	return nil
+}

--- a/lacework/resource_lacework_integration_docker_v2_test.go
+++ b/lacework/resource_lacework_integration_docker_v2_test.go
@@ -1,0 +1,161 @@
+package lacework
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/lacework/go-sdk/api"
+)
+
+const (
+	testAccIntegrationDockerV2ResourceType = "lacework_integration_docker_v2"
+	testAccIntegrationDockerV2ResourceName = "example"
+
+	// Environment variables for testing Docker V2 Container Registry Integrations
+	testAccIntegrationDockerV2EnvRegistryDomain = "DOCKER_V2_DOMAIN"
+	testAccIntegrationDockerV2EnvUsername       = "DOCKER_V2_USERNAME"
+	testAccIntegrationDockerV2EnvPassword       = "DOCKER_V2_PASSWORD"
+	testAccIntegrationDockerV2EnvSSL            = "DOCKER_V2_SSL"
+)
+
+func TestAccIntegrationDockerV2(t *testing.T) {
+	resourceTypeAndName := fmt.Sprintf("%s.%s",
+		testAccIntegrationDockerV2ResourceType,
+		testAccIntegrationDockerV2ResourceName,
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccIntegrationDockerV2EnvVarsPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIntegrationDockerV2Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIntegrationDockerV2Config(
+					true,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIntegrationDockerV2Exists(resourceTypeAndName),
+					resource.TestCheckResourceAttr(resourceTypeAndName, "enabled", "true"),
+				),
+			},
+			{
+				Config: testAccIntegrationDockerV2Config(
+					false,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIntegrationDockerV2Exists(resourceTypeAndName),
+					resource.TestCheckResourceAttr(resourceTypeAndName, "enabled", "false"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIntegrationDockerV2Destroy(s *terraform.State) error {
+	lacework := testAccProvider.Meta().(*api.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != testAccIntegrationDockerV2ResourceType {
+			continue
+		}
+
+		response, err := lacework.Integrations.GetSlackAlertChannel(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		for _, integration := range response.Data {
+			if integration.IntgGuid == rs.Primary.ID {
+				return fmt.Errorf(
+					"the %s integration (%s) still exists",
+					api.SlackChannelIntegration, rs.Primary.ID,
+				)
+			}
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckIntegrationDockerV2Exists(resourceTypeAndName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		lacework := testAccProvider.Meta().(*api.Client)
+
+		rs, ok := s.RootModule().Resources[resourceTypeAndName]
+		if !ok {
+			return fmt.Errorf("resource (%s) not found", resourceTypeAndName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("resource (%s) ID not set", resourceTypeAndName)
+		}
+
+		response, err := lacework.Integrations.GetSlackAlertChannel(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if len(response.Data) < 1 {
+			return fmt.Errorf("the %s integration (%s) doesn't exist",
+				api.SlackChannelIntegration, rs.Primary.ID)
+		}
+
+		for _, integration := range response.Data {
+			if integration.IntgGuid == rs.Primary.ID {
+				return nil
+			}
+		}
+
+		return fmt.Errorf("the %s integration (%s) doesn't exist",
+			api.SlackChannelIntegration, rs.Primary.ID)
+	}
+}
+
+func testAccIntegrationDockerV2EnvVarsPreCheck(t *testing.T) {
+	if v := os.Getenv(testAccIntegrationContainerRegEnvLimitByTag); v == "" {
+		t.Fatalf("%s must be set for acceptance tests", testAccIntegrationContainerRegEnvLimitByTag)
+	}
+	if v := os.Getenv(testAccIntegrationContainerRegEnvLimitByLabel); v == "" {
+		t.Fatalf("%s must be set for acceptance tests", testAccIntegrationContainerRegEnvLimitByLabel)
+	}
+	if v := os.Getenv(testAccIntegrationDockerV2EnvRegistryDomain); v == "" {
+		t.Fatalf("%s must be set for acceptance tests", testAccIntegrationDockerV2EnvRegistryDomain)
+	}
+	if v := os.Getenv(testAccIntegrationDockerV2EnvUsername); v == "" {
+		t.Fatalf("%s must be set for acceptance tests", testAccIntegrationDockerV2EnvUsername)
+	}
+	if v := os.Getenv(testAccIntegrationDockerV2EnvPassword); v == "" {
+		t.Fatalf("%s must be set for acceptance tests", testAccIntegrationDockerV2EnvPassword)
+	}
+}
+
+func testAccIntegrationDockerV2Config(enabled bool) string {
+	return fmt.Sprintf(`
+resource "%s" "%s" {
+    name            = "integration test"
+    enabled         = %t
+    registry_domain = "%s"
+    username        = "%s"
+    password        = "%s"
+    ssl             = %s
+    limit_by_tag    = "%s"
+    limit_by_label  = "%s"
+}
+`,
+		testAccIntegrationDockerV2ResourceType,
+		testAccIntegrationDockerV2ResourceName,
+		enabled,
+		os.Getenv(testAccIntegrationDockerV2EnvRegistryDomain),
+		os.Getenv(testAccIntegrationDockerV2EnvUsername),
+		os.Getenv(testAccIntegrationDockerV2EnvPassword),
+		os.Getenv(testAccIntegrationDockerV2EnvSSL),
+		os.Getenv(testAccIntegrationContainerRegEnvLimitByTag),
+		os.Getenv(testAccIntegrationContainerRegEnvLimitByLabel),
+	)
+}

--- a/lacework/resource_lacework_integration_ecr.go
+++ b/lacework/resource_lacework_integration_ecr.go
@@ -1,0 +1,236 @@
+package lacework
+
+import (
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+
+	"github.com/lacework/go-sdk/api"
+)
+
+func resourceLaceworkIntegrationEcr() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceLaceworkIntegrationEcrCreate,
+		Read:   resourceLaceworkIntegrationEcrRead,
+		Update: resourceLaceworkIntegrationEcrUpdate,
+		Delete: resourceLaceworkIntegrationEcrDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: importLaceworkIntegration,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"registry_domain": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"access_key_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"secret_access_key": {
+				Type:      schema.TypeString,
+				Required:  true,
+				Sensitive: true,
+			},
+			"limit_by_tag": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "*",
+			},
+			"limit_by_label": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "*",
+			},
+			"limit_by_repos": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
+			"limit_num_imgs": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  5,
+			},
+			"intg_guid": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_or_updated_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_or_updated_by": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"type_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"org_level": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceLaceworkIntegrationEcrCreate(d *schema.ResourceData, meta interface{}) error {
+	lacework := meta.(*api.Client)
+	data := api.NewAwsEcrRegistryIntegration(d.Get("name").(string),
+		api.AwsEcrData{
+			LimitByTag:     d.Get("limit_by_tag").(string),
+			LimitByLabel:   d.Get("limit_by_label").(string),
+			LimitByRep:     d.Get("limit_by_repos").(string),
+			LimitNumImg:    d.Get("limit_num_imgs").(int),
+			RegistryDomain: d.Get("registry_domain").(string),
+			Credentials: api.AwsEcrCreds{
+				AccessKeyID:     d.Get("access_key_id").(string),
+				SecretAccessKey: d.Get("secret_access_key").(string),
+			},
+		},
+	)
+
+	if !d.Get("enabled").(bool) {
+		data.Enabled = 0
+	}
+
+	log.Printf("[INFO] Creating %s integration %s registry type with data:\n%+v\n",
+		api.ContainerRegistryIntegration.String(), api.EcrRegistry.String(), data)
+	response, err := lacework.Integrations.CreateAwsEcrRegistry(data)
+	if err != nil {
+		return err
+	}
+
+	for _, integration := range response.Data {
+		d.SetId(integration.IntgGuid)
+		d.Set("name", integration.Name)
+		d.Set("intg_guid", integration.IntgGuid)
+		d.Set("enabled", integration.Enabled == 1)
+		d.Set("created_or_updated_time", integration.CreatedOrUpdatedTime)
+		d.Set("created_or_updated_by", integration.CreatedOrUpdatedBy)
+		d.Set("type_name", integration.TypeName)
+		d.Set("org_level", integration.IsOrg == 1)
+
+		log.Printf("[INFO] Created %s integration %s registry type with guid: %v\n",
+			api.ContainerRegistryIntegration.String(), api.EcrRegistry.String(), integration.IntgGuid)
+		return nil
+	}
+
+	return nil
+}
+
+func resourceLaceworkIntegrationEcrRead(d *schema.ResourceData, meta interface{}) error {
+	lacework := meta.(*api.Client)
+
+	log.Printf("[INFO] Reading %s integration %s registry type with guid: %v\n",
+		api.ContainerRegistryIntegration.String(), api.EcrRegistry.String(), d.Id())
+	response, err := lacework.Integrations.GetAwsEcrRegistry(d.Id())
+
+	if err != nil {
+		return err
+	}
+
+	for _, integration := range response.Data {
+		if integration.IntgGuid == d.Id() {
+			d.Set("name", integration.Name)
+			d.Set("intg_guid", integration.IntgGuid)
+			d.Set("enabled", integration.Enabled == 1)
+			d.Set("created_or_updated_time", integration.CreatedOrUpdatedTime)
+			d.Set("created_or_updated_by", integration.CreatedOrUpdatedBy)
+			d.Set("type_name", integration.TypeName)
+			d.Set("org_level", integration.IsOrg == 1)
+
+			d.Set("access_key_id", integration.Data.Credentials.AccessKeyID)
+			d.Set("registry_domain", integration.Data.RegistryDomain)
+			d.Set("limit_by_tag", integration.Data.LimitByTag)
+			d.Set("limit_by_label", integration.Data.LimitByLabel)
+			d.Set("limit_by_repos", integration.Data.LimitByRep)
+			d.Set("limit_num_imgs", integration.Data.LimitNumImg)
+
+			log.Printf("[INFO] Read %s integration %s registry type with guid: %v\n",
+				api.ContainerRegistryIntegration.String(), api.EcrRegistry.String(), integration.IntgGuid)
+			return nil
+		}
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func resourceLaceworkIntegrationEcrUpdate(d *schema.ResourceData, meta interface{}) error {
+	lacework := meta.(*api.Client)
+	data := api.NewAwsEcrRegistryIntegration(d.Get("name").(string),
+		api.AwsEcrData{
+			LimitByTag:     d.Get("limit_by_tag").(string),
+			LimitByLabel:   d.Get("limit_by_label").(string),
+			LimitByRep:     d.Get("limit_by_repos").(string),
+			LimitNumImg:    d.Get("limit_num_imgs").(int),
+			RegistryDomain: d.Get("registry_domain").(string),
+			Credentials: api.AwsEcrCreds{
+				AccessKeyID:     d.Get("access_key_id").(string),
+				SecretAccessKey: d.Get("secret_access_key").(string),
+			},
+		},
+	)
+
+	if !d.Get("enabled").(bool) {
+		data.Enabled = 0
+	}
+
+	data.IntgGuid = d.Id()
+
+	log.Printf("[INFO] Updating %s integration %s registry type with data:\n%+v\n",
+		api.ContainerRegistryIntegration.String(), api.EcrRegistry.String(), data)
+	response, err := lacework.Integrations.UpdateAwsEcrRegistry(data)
+	if err != nil {
+		return err
+	}
+
+	for _, integration := range response.Data {
+		if integration.IntgGuid == d.Id() {
+			d.Set("name", integration.Name)
+			d.Set("intg_guid", integration.IntgGuid)
+			d.Set("enabled", integration.Enabled == 1)
+			d.Set("created_or_updated_time", integration.CreatedOrUpdatedTime)
+			d.Set("created_or_updated_by", integration.CreatedOrUpdatedBy)
+			d.Set("type_name", integration.TypeName)
+			d.Set("org_level", integration.IsOrg == 1)
+
+			log.Printf("[INFO] Updated %s integration %s registry type with guid: %v\n",
+				api.ContainerRegistryIntegration.String(), api.EcrRegistry.String(), d.Id())
+
+			return nil
+		}
+	}
+
+	return nil
+}
+
+func resourceLaceworkIntegrationEcrDelete(d *schema.ResourceData, meta interface{}) error {
+	lacework := meta.(*api.Client)
+
+	log.Printf("[INFO] Deleting %s integration %s registry type with guid: %v\n",
+		api.ContainerRegistryIntegration.String(), api.EcrRegistry.String(), d.Id())
+
+	_, err := lacework.Integrations.Delete(d.Id())
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[INFO] Deleted %s integration %s registry type with guid: %v\n",
+		api.ContainerRegistryIntegration.String(), api.EcrRegistry.String(), d.Id())
+
+	return nil
+}

--- a/lacework/resource_lacework_integration_gcr.go
+++ b/lacework/resource_lacework_integration_gcr.go
@@ -1,0 +1,287 @@
+package lacework
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+
+	"github.com/lacework/go-sdk/api"
+)
+
+func resourceLaceworkIntegrationGcr() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceLaceworkIntegrationGcrCreate,
+		Read:   resourceLaceworkIntegrationGcrRead,
+		Update: resourceLaceworkIntegrationGcrUpdate,
+		Delete: resourceLaceworkIntegrationGcrDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: importLaceworkIntegration,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"registry_domain": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: func(value interface{}, key string) ([]string, []error) {
+					switch value.(string) {
+					case "gcr.io", "us.gcr.io", "eu.gcr.io", "asia.gcr.io":
+						return nil, nil
+					default:
+						return nil, []error{
+							fmt.Errorf(
+								"%s: can only be one of 'gcr.io', 'us.gcr.io', 'eu.gcr.io', or 'asia.gcr.io'", key,
+							),
+						}
+					}
+				},
+			},
+			"credentials": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"client_id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"private_key_id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"client_email": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"private_key": {
+							Type:      schema.TypeString,
+							Required:  true,
+							Sensitive: true,
+							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+								// @afiune we can't compare this element since our API, for security reasons,
+								// does NOT return the private key configured in the Lacework server. So if
+								// any other element changed from the credentials then we trigger a diff
+								if d.HasChanges(
+									"name", "limit_by_tag", "limit_by_label", "org_level", "enabled",
+									"credentials.0.client_id", "credentials.0.private_key_id",
+									"credentials.0.client_email", "limit_by_repos", "limit_num_imgs",
+								) {
+									return false
+								}
+								return true
+							},
+						},
+					},
+				},
+			},
+			"limit_by_tag": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "*",
+			},
+			"limit_by_label": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "*",
+			},
+			"limit_by_repos": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
+			"limit_num_imgs": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  5,
+			},
+			"intg_guid": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_or_updated_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created_or_updated_by": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"type_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"org_level": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceLaceworkIntegrationGcrCreate(d *schema.ResourceData, meta interface{}) error {
+	lacework := meta.(*api.Client)
+	data := api.NewGcrRegistryIntegration(d.Get("name").(string),
+		api.ContainerRegData{
+			LimitByTag:     d.Get("limit_by_tag").(string),
+			LimitByLabel:   d.Get("limit_by_label").(string),
+			LimitByRep:     d.Get("limit_by_repos").(string),
+			LimitNumImg:    d.Get("limit_num_imgs").(int),
+			RegistryDomain: d.Get("registry_domain").(string),
+			Credentials: api.ContainerRegCreds{
+				ClientID:     d.Get("credentials.0.client_id").(string),
+				ClientEmail:  d.Get("credentials.0.client_email").(string),
+				PrivateKeyID: d.Get("credentials.0.private_key_id").(string),
+				PrivateKey:   d.Get("credentials.0.private_key").(string),
+			},
+		},
+	)
+
+	if !d.Get("enabled").(bool) {
+		data.Enabled = 0
+	}
+
+	log.Printf("[INFO] Creating %s integration %s registry type with data:\n%+v\n",
+		api.ContainerRegistryIntegration.String(), api.GcrRegistry.String(), data)
+	response, err := lacework.Integrations.CreateContainerRegistry(data)
+	if err != nil {
+		return err
+	}
+
+	for _, integration := range response.Data {
+		d.SetId(integration.IntgGuid)
+		d.Set("name", integration.Name)
+		d.Set("intg_guid", integration.IntgGuid)
+		d.Set("enabled", integration.Enabled == 1)
+		d.Set("created_or_updated_time", integration.CreatedOrUpdatedTime)
+		d.Set("created_or_updated_by", integration.CreatedOrUpdatedBy)
+		d.Set("type_name", integration.TypeName)
+		d.Set("org_level", integration.IsOrg == 1)
+
+		log.Printf("[INFO] Created %s integration %s registry type with guid: %v\n",
+			api.ContainerRegistryIntegration.String(), api.GcrRegistry.String(), integration.IntgGuid)
+		return nil
+	}
+
+	return nil
+}
+
+func resourceLaceworkIntegrationGcrRead(d *schema.ResourceData, meta interface{}) error {
+	lacework := meta.(*api.Client)
+
+	log.Printf("[INFO] Reading %s integration %s registry type with guid: %v\n",
+		api.ContainerRegistryIntegration.String(), api.GcrRegistry.String(), d.Id())
+	response, err := lacework.Integrations.GetContainerRegistry(d.Id())
+
+	if err != nil {
+		return err
+	}
+
+	for _, integration := range response.Data {
+		if integration.IntgGuid == d.Id() {
+			d.Set("name", integration.Name)
+			d.Set("intg_guid", integration.IntgGuid)
+			d.Set("enabled", integration.Enabled == 1)
+			d.Set("created_or_updated_time", integration.CreatedOrUpdatedTime)
+			d.Set("created_or_updated_by", integration.CreatedOrUpdatedBy)
+			d.Set("type_name", integration.TypeName)
+			d.Set("org_level", integration.IsOrg == 1)
+
+			creds := make(map[string]string)
+			creds["client_id"] = integration.Data.Credentials.ClientID
+			creds["client_email"] = integration.Data.Credentials.ClientEmail
+			creds["private_key_id"] = integration.Data.Credentials.PrivateKeyID
+			d.Set("credentials", []map[string]string{creds})
+			d.Set("registry_domain", integration.Data.RegistryDomain)
+			d.Set("limit_by_tag", integration.Data.LimitByTag)
+			d.Set("limit_by_label", integration.Data.LimitByLabel)
+			d.Set("limit_by_repos", integration.Data.LimitByRep)
+			d.Set("limit_num_imgs", integration.Data.LimitNumImg)
+
+			log.Printf("[INFO] Read %s integration %s registry type with guid: %v\n",
+				api.ContainerRegistryIntegration.String(), api.GcrRegistry.String(), integration.IntgGuid)
+			return nil
+		}
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func resourceLaceworkIntegrationGcrUpdate(d *schema.ResourceData, meta interface{}) error {
+	lacework := meta.(*api.Client)
+	data := api.NewGcrRegistryIntegration(d.Get("name").(string),
+		api.ContainerRegData{
+			LimitByTag:     d.Get("limit_by_tag").(string),
+			LimitByLabel:   d.Get("limit_by_label").(string),
+			LimitByRep:     d.Get("limit_by_repos").(string),
+			LimitNumImg:    d.Get("limit_num_imgs").(int),
+			RegistryDomain: d.Get("registry_domain").(string),
+			Credentials: api.ContainerRegCreds{
+				ClientID:     d.Get("credentials.0.client_id").(string),
+				ClientEmail:  d.Get("credentials.0.client_email").(string),
+				PrivateKeyID: d.Get("credentials.0.private_key_id").(string),
+				PrivateKey:   d.Get("credentials.0.private_key").(string),
+			},
+		},
+	)
+
+	if !d.Get("enabled").(bool) {
+		data.Enabled = 0
+	}
+
+	data.IntgGuid = d.Id()
+
+	log.Printf("[INFO] Updating %s integration %s registry type with data:\n%+v\n",
+		api.ContainerRegistryIntegration.String(), api.GcrRegistry.String(), data)
+	response, err := lacework.Integrations.UpdateContainerRegistry(data)
+	if err != nil {
+		return err
+	}
+
+	for _, integration := range response.Data {
+		if integration.IntgGuid == d.Id() {
+			d.Set("name", integration.Name)
+			d.Set("intg_guid", integration.IntgGuid)
+			d.Set("enabled", integration.Enabled == 1)
+			d.Set("created_or_updated_time", integration.CreatedOrUpdatedTime)
+			d.Set("created_or_updated_by", integration.CreatedOrUpdatedBy)
+			d.Set("type_name", integration.TypeName)
+			d.Set("org_level", integration.IsOrg == 1)
+
+			log.Printf("[INFO] Updated %s integration %s registry type with guid: %v\n",
+				api.ContainerRegistryIntegration.String(), api.GcrRegistry.String(), d.Id())
+
+			return nil
+		}
+	}
+
+	return nil
+}
+
+func resourceLaceworkIntegrationGcrDelete(d *schema.ResourceData, meta interface{}) error {
+	lacework := meta.(*api.Client)
+
+	log.Printf("[INFO] Deleting %s integration %s registry type with guid: %v\n",
+		api.ContainerRegistryIntegration.String(), api.GcrRegistry.String(), d.Id())
+
+	_, err := lacework.Integrations.Delete(d.Id())
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[INFO] Deleted %s integration %s registry type with guid: %v\n",
+		api.ContainerRegistryIntegration.String(), api.GcrRegistry.String(), d.Id())
+
+	return nil
+}

--- a/lacework/resource_lacework_integration_gcr_test.go
+++ b/lacework/resource_lacework_integration_gcr_test.go
@@ -1,0 +1,182 @@
+package lacework
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/lacework/go-sdk/api"
+)
+
+const (
+	testAccIntegrationGcrResourceType = "lacework_integration_gcr"
+	testAccIntegrationGcrResourceName = "example"
+
+	// Environment variables for testing GCR Integrations
+	testAccIntegrationGcrEnvRegistryDomain = "GCR_DOMAIN"
+	testAccIntegrationGcrEnvClientID       = "GCR_CLIENT_ID"
+	testAccIntegrationGcrEnvPrivateKeyID   = "GCR_PRIVATE_KEY_ID"
+	testAccIntegrationGcrEnvPrivateKey     = "GCR_PRIVATE_KEY"
+	testAccIntegrationGcrEnvClientEmail    = "GCR_CLIENT_EMAIL"
+)
+
+func TestAccIntegrationGcr(t *testing.T) {
+	resourceTypeAndName := fmt.Sprintf("%s.%s",
+		testAccIntegrationGcrResourceType,
+		testAccIntegrationGcrResourceName,
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccIntegrationGcrEnvVarsPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIntegrationGcrDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIntegrationGcrConfig(
+					true,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIntegrationGcrExists(resourceTypeAndName),
+					resource.TestCheckResourceAttr(resourceTypeAndName, "enabled", "true"),
+				),
+			},
+			{
+				Config: testAccIntegrationGcrConfig(
+					false,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIntegrationGcrExists(resourceTypeAndName),
+					resource.TestCheckResourceAttr(resourceTypeAndName, "enabled", "false"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIntegrationGcrDestroy(s *terraform.State) error {
+	lacework := testAccProvider.Meta().(*api.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != testAccIntegrationGcrResourceType {
+			continue
+		}
+
+		response, err := lacework.Integrations.GetSlackAlertChannel(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		for _, integration := range response.Data {
+			if integration.IntgGuid == rs.Primary.ID {
+				return fmt.Errorf(
+					"the %s integration (%s) still exists",
+					api.SlackChannelIntegration, rs.Primary.ID,
+				)
+			}
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckIntegrationGcrExists(resourceTypeAndName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		lacework := testAccProvider.Meta().(*api.Client)
+
+		rs, ok := s.RootModule().Resources[resourceTypeAndName]
+		if !ok {
+			return fmt.Errorf("resource (%s) not found", resourceTypeAndName)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("resource (%s) ID not set", resourceTypeAndName)
+		}
+
+		response, err := lacework.Integrations.GetSlackAlertChannel(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if len(response.Data) < 1 {
+			return fmt.Errorf("the %s integration (%s) doesn't exist",
+				api.SlackChannelIntegration, rs.Primary.ID)
+		}
+
+		for _, integration := range response.Data {
+			if integration.IntgGuid == rs.Primary.ID {
+				return nil
+			}
+		}
+
+		return fmt.Errorf("the %s integration (%s) doesn't exist",
+			api.SlackChannelIntegration, rs.Primary.ID)
+	}
+}
+
+func testAccIntegrationGcrEnvVarsPreCheck(t *testing.T) {
+	if v := os.Getenv(testAccIntegrationContainerRegEnvLimitByTag); v == "" {
+		t.Fatalf("%s must be set for acceptance tests", testAccIntegrationContainerRegEnvLimitByTag)
+	}
+	if v := os.Getenv(testAccIntegrationContainerRegEnvLimitByLabel); v == "" {
+		t.Fatalf("%s must be set for acceptance tests", testAccIntegrationContainerRegEnvLimitByLabel)
+	}
+	if v := os.Getenv(testAccIntegrationContainerRegEnvLimitByRepos); v == "" {
+		t.Fatalf("%s must be set for acceptance tests", testAccIntegrationContainerRegEnvLimitByRepos)
+	}
+	if v := os.Getenv(testAccIntegrationContainerRegEnvLimitNumImg); v == "" {
+		t.Fatalf("%s must be set for acceptance tests", testAccIntegrationContainerRegEnvLimitNumImg)
+	}
+	if v := os.Getenv(testAccIntegrationGcrEnvRegistryDomain); v == "" {
+		t.Fatalf("%s must be set for acceptance tests", testAccIntegrationGcrEnvRegistryDomain)
+	}
+	if v := os.Getenv(testAccIntegrationGcrEnvClientID); v == "" {
+		t.Fatalf("%s must be set for acceptance tests", testAccIntegrationGcrEnvClientID)
+	}
+	if v := os.Getenv(testAccIntegrationGcrEnvPrivateKeyID); v == "" {
+		t.Fatalf("%s must be set for acceptance tests", testAccIntegrationGcrEnvPrivateKeyID)
+	}
+	if v := os.Getenv(testAccIntegrationGcrEnvPrivateKey); v == "" {
+		t.Fatalf("%s must be set for acceptance tests", testAccIntegrationGcrEnvPrivateKey)
+	}
+	if v := os.Getenv(testAccIntegrationGcrEnvClientEmail); v == "" {
+		t.Fatalf("%s must be set for acceptance tests", testAccIntegrationGcrEnvClientEmail)
+	}
+}
+
+func testAccIntegrationGcrConfig(enabled bool) string {
+	return fmt.Sprintf(`
+resource "%s" "%s" {
+    name            = "integration test"
+    enabled         = %t
+    registry_domain = "%s"
+    credentials {
+        client_id = "%s"
+        private_key_id = "%s"
+        client_email = "%s"
+        private_key = "%s"
+    }
+    limit_by_tag    = "%s"
+    limit_by_label  = "%s"
+    limit_by_repos = "%s"
+    limit_num_imgs = %s
+}
+`,
+		testAccIntegrationGcrResourceType,
+		testAccIntegrationGcrResourceName,
+		enabled,
+		os.Getenv(testAccIntegrationGcrEnvRegistryDomain),
+		os.Getenv(testAccIntegrationGcrEnvClientID),
+		os.Getenv(testAccIntegrationGcrEnvPrivateKeyID),
+		os.Getenv(testAccIntegrationGcrEnvClientEmail),
+		os.Getenv(testAccIntegrationGcrEnvPrivateKey),
+		os.Getenv(testAccIntegrationContainerRegEnvLimitByTag),
+		os.Getenv(testAccIntegrationContainerRegEnvLimitByLabel),
+		os.Getenv(testAccIntegrationContainerRegEnvLimitByRepos),
+		os.Getenv(testAccIntegrationContainerRegEnvLimitNumImg),
+	)
+}

--- a/website/docs/r/integration_aws_cfg.html.markdown
+++ b/website/docs/r/integration_aws_cfg.html.markdown
@@ -25,7 +25,7 @@ resource "lacework_integration_aws_cfg" "account_abc" {
 
 The following arguments are supported:
 
-* `name` - (Required) The Lacework AWS Config integration name.
+* `name` - (Required) The AWS Config integration name.
 * `credentials` - (Required) The credentials needed by the integration. See [Credentials](#credentials) below for details.
 * `enabled` - (Optional) The state of the external integration. Defaults to `true`.
 

--- a/website/docs/r/integration_aws_ct.html.markdown
+++ b/website/docs/r/integration_aws_ct.html.markdown
@@ -27,7 +27,7 @@ resource "lacework_integration_aws_ct" "account_abc" {
 
 The following arguments are supported:
 
-* `name` - (Required) The Lacework AWS CloudTrail integration name.
+* `name` - (Required) The AWS CloudTrail integration name.
 * `queue_url` - (Required) The SQS Queue URL.
 * `credentials` - (Required) The credentials needed by the integration. See [Credentials](#credentials) below for details.
 * `enabled` - (Optional) The state of the external integration. Defaults to `true`.

--- a/website/docs/r/integration_azure_al.html.markdown
+++ b/website/docs/r/integration_azure_al.html.markdown
@@ -28,7 +28,7 @@ resource "lacework_integration_azure_at" "account_abc" {
 
 The following arguments are supported:
 
-* `name` - (Required) The Lacework Azure Config integration name.
+* `name` - (Required) The Azure Activity Log integration name.
 * `tenant_id` - (Required) The directory tenant ID.
 * `queue_url` - (Required) The storage queue URL.
 * `credentials` - (Required) The credentials needed by the integration. See [Credentials](#credentials) below for details.

--- a/website/docs/r/integration_azure_cfg.html.markdown
+++ b/website/docs/r/integration_azure_cfg.html.markdown
@@ -26,7 +26,7 @@ resource "lacework_integration_azure_cfg" "account_abc" {
 
 The following arguments are supported:
 
-* `name` - (Required) The Lacework Azure Config integration name.
+* `name` - (Required) The Azure Config integration name.
 * `tenant_id` - (Required) The directory tenant ID.
 * `credentials` - (Required) The credentials needed by the integration. See [Credentials](#credentials) below for details.
 * `enabled` - (Optional) The state of the external integration. Defaults to `true`.

--- a/website/docs/r/integration_docker_hub.html.markdown
+++ b/website/docs/r/integration_docker_hub.html.markdown
@@ -25,7 +25,7 @@ resource "lacework_integration_docker_hub" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The Lacework container registry integration name.
+* `name` - (Required) The Container Registry integration name.
 * `username` - (Required) The Docker user that has at least read-only permissions to the Docker Hub container repositories.
 * `password` - (Required) The password for the specified Docker Hub user.
 * `limit_by_tag` - (Optional) An image tag to limit the assessment of images with matching tag. If you specify `limit_by_tag` and `limit_by_label` limits, they function as an `AND`. Supported field input are `mytext*mytext`, `mytext`, `mytext*`, or `mytext`. Only one `*` wildcard is supported. Defaults to `*`.

--- a/website/docs/r/integration_docker_hub.html.markdown
+++ b/website/docs/r/integration_docker_hub.html.markdown
@@ -28,8 +28,8 @@ The following arguments are supported:
 * `name` - (Required) The Lacework container registry integration name.
 * `username` - (Required) The Docker user that has at least read-only permissions to the Docker Hub container repositories.
 * `password` - (Required) The password for the specified Docker Hub user.
-* `limit_by_tag` - (Optional) An image tag to limit the assessment of images with matching tag. If you specify `limit_by_tag` and `limit_by_label` limits, they function as an `AND`. Supported field input are: `mytext*mytext`, `mytext`, `mytext*`, or `mytext`. Only one `*` wildcard is supported. Defaults to `*`.
-* `limit_by_label` - (Optional) An image label to limit the assessment of images with matching label. If you specify `limit_by_tag` and `limit_by_label` limits, they function as an `AND`. Supported field input are: `mytext*mytext`, `mytext`, `mytext*`, or `mytext`. Only one `*` wildcard is supported. Defaults to `*`.
+* `limit_by_tag` - (Optional) An image tag to limit the assessment of images with matching tag. If you specify `limit_by_tag` and `limit_by_label` limits, they function as an `AND`. Supported field input are `mytext*mytext`, `mytext`, `mytext*`, or `mytext`. Only one `*` wildcard is supported. Defaults to `*`.
+* `limit_by_label` - (Optional) An image label to limit the assessment of images with matching label. If you specify `limit_by_tag` and `limit_by_label` limits, they function as an `AND`. Supported field input are `mytext*mytext`, `mytext`, `mytext*`, or `mytext`. Only one `*` wildcard is supported. Defaults to `*`.
 * `limit_by_repos` - (Optional) A comma-separated list of repositories to assess. (without spaces recommended)
 * `limit_num_imgs` - (Optional) The maximum number of newest container images to assess per repository. Must be one of `5`, `10`, or `15`. Defaults to `5`.
 * `enabled` - (Optional) The state of the external integration. Defaults to `true`.

--- a/website/docs/r/integration_docker_v2.html.markdown
+++ b/website/docs/r/integration_docker_v2.html.markdown
@@ -1,0 +1,71 @@
+---
+layout: "lacework"
+page_title: "Lacework: lacework_integration_docker_v2"
+description: |-
+  Create and manage Docker V2 container registry integrations
+---
+
+# lacework\_integration\_docker\_v2
+
+Use the Docker V2 Registry integration for private Docker V2 registries only.
+
+~> **Note:** For Docker Hub, ECR, and GCR, use their corresponding container registry types.
+
+The Docker V2 Registry integration functions differently than Lacework's other container registry
+integrations. This integration performs on-demand image assessment via the CLI/API, while the other
+integrations automatically assess images at regular intervals.
+
+Supported Docker V2 registries:
+
+* Azure Container Registry
+* GitLab (On prem 12.8 and cloud)
+* JFrog Artifactory (On prem 7.2.1 and cloud)
+* JFrog Platform (On prem 7.2.1 and cloud)
+
+~> **Note:** You must whitelist the Lacework outbound IPs to allow the vulnerability scanner to communicate with your private registries. See [Lacework Outbound IPs](https://support.lacework.com/hc/en-us/articles/360052140433)
+
+## Set Up Image Assessments
+
+The Lacework CLI makes it easy to request on-demand scans of new images designed for continuous
+integration (CI) pipelines. You can find more information on integrating the Lacework CLI for
+container vulnerability scanning in CI pipelines [here](https://support.lacework.com/hc/en-us/articles/360052476154-Integrate-Lacework-APIs-with-Continuous-Integration-CI-Pipelines).
+
+-> **Note:** The Docker V2 Registry status displays Integration Successful only after its first assessment completes. 
+
+For more information visit the [documentation for the Lacework CLI](https://github.com/lacework/go-sdk/wiki/CLI-Documentation#container-vulnerability-assessments).
+
+## Example Usage
+
+```hcl
+resource "lacework_integration_docker_v2" "jfrog" {
+  name = "My Docker V2 Registry"
+  registry_domain = "my-dockerv2.jfrog.io"
+  username = "my-user"
+  password = "a-secret-password"
+  ssl = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The Lacework container registry integration name.
+* `registry_domain` - (Required) The registry domain. Allowed formats are `YourIP:YourPort` or `YourDomain:YourPort`.
+* `username` - (Required) The user that has at permissions to pull from the container registry the images to be assessed.
+* `password` - (Required) The password for the specified user.
+* `ssl` - (Optional) Enable or disable SSL communication. Defaults to `false`.
+* `limit_by_tag` - (Optional) An image tag to limit the assessment of images with matching tag. If you specify `limit_by_tag` and `limit_by_label` limits, they function as an `AND`. Supported field input are: `mytext*mytext`, `mytext`, `mytext*`, or `mytext`. Only one `*` wildcard is supported. Defaults to `*`.
+* `limit_by_label` - (Optional) An image label to limit the assessment of images with matching label. If you specify `limit_by_tag` and `limit_by_label` limits, they function as an `AND`. Supported field input are: `mytext*mytext`, `mytext`, `mytext*`, or `mytext`. Only one `*` wildcard is supported. Defaults to `*`.
+* `enabled` - (Optional) The state of the external integration. Defaults to `true`.
+
+## Import
+
+A Lacework Docker V2 container registry integration can be imported using a `INT_GUID`, e.g.
+
+```
+$ terraform import lacework_integration_docker_v2.jfrog EXAMPLE_1234BAE1E42182964D23973F44CFEA3C4AB63B99E9A1EC5
+```
+-> **Note:** To retreive the `INT_GUID` from existing integrations in your account, use the
+	Lacework CLI command `lacework integration list`. To install this tool follow
+	[this documentation](https://github.com/lacework/go-sdk/wiki/CLI-Documentation#installation).

--- a/website/docs/r/integration_docker_v2.html.markdown
+++ b/website/docs/r/integration_docker_v2.html.markdown
@@ -12,7 +12,7 @@ Use the Docker V2 Registry integration for private Docker V2 registries only.
 ~> **Note:** For Docker Hub, ECR, and GCR, use their corresponding container registry types.
 
 The Docker V2 Registry integration functions differently than Lacework's other container registry
-integrations. This integration performs on-demand image assessment via the CLI/API, while the other
+integrations. This integration performs on-demand image assessment via the Lacework API, while the other
 integrations automatically assess images at regular intervals.
 
 Supported Docker V2 registries:
@@ -30,7 +30,7 @@ The Lacework CLI makes it easy to request on-demand scans of new images designed
 integration (CI) pipelines. You can find more information on integrating the Lacework CLI for
 container vulnerability scanning in CI pipelines [here](https://support.lacework.com/hc/en-us/articles/360052476154-Integrate-Lacework-APIs-with-Continuous-Integration-CI-Pipelines).
 
--> **Note:** The Docker V2 Registry status displays Integration Successful only after its first assessment completes. 
+-> **Note:** The Docker V2 Registry status displays `Integration Successful` only after its first assessment completes.
 
 For more information visit the [documentation for the Lacework CLI](https://github.com/lacework/go-sdk/wiki/CLI-Documentation#container-vulnerability-assessments).
 
@@ -50,7 +50,7 @@ resource "lacework_integration_docker_v2" "jfrog" {
 
 The following arguments are supported:
 
-* `name` - (Required) The Lacework container registry integration name.
+* `name` - (Required) The Docker V2 Registry integration name.
 * `registry_domain` - (Required) The registry domain. Allowed formats are `YourIP:YourPort` or `YourDomain:YourPort`.
 * `username` - (Required) The user that has at permissions to pull from the container registry the images to be assessed.
 * `password` - (Required) The password for the specified user.

--- a/website/docs/r/integration_docker_v2.html.markdown
+++ b/website/docs/r/integration_docker_v2.html.markdown
@@ -55,8 +55,8 @@ The following arguments are supported:
 * `username` - (Required) The user that has at permissions to pull from the container registry the images to be assessed.
 * `password` - (Required) The password for the specified user.
 * `ssl` - (Optional) Enable or disable SSL communication. Defaults to `false`.
-* `limit_by_tag` - (Optional) An image tag to limit the assessment of images with matching tag. If you specify `limit_by_tag` and `limit_by_label` limits, they function as an `AND`. Supported field input are: `mytext*mytext`, `mytext`, `mytext*`, or `mytext`. Only one `*` wildcard is supported. Defaults to `*`.
-* `limit_by_label` - (Optional) An image label to limit the assessment of images with matching label. If you specify `limit_by_tag` and `limit_by_label` limits, they function as an `AND`. Supported field input are: `mytext*mytext`, `mytext`, `mytext*`, or `mytext`. Only one `*` wildcard is supported. Defaults to `*`.
+* `limit_by_tag` - (Optional) An image tag to limit the assessment of images with matching tag. If you specify `limit_by_tag` and `limit_by_label` limits, they function as an `AND`. Supported field input are `mytext*mytext`, `mytext`, `mytext*`, or `mytext`. Only one `*` wildcard is supported. Defaults to `*`.
+* `limit_by_label` - (Optional) An image label to limit the assessment of images with matching label. If you specify `limit_by_tag` and `limit_by_label` limits, they function as an `AND`. Supported field input are `mytext*mytext`, `mytext`, `mytext*`, or `mytext`. Only one `*` wildcard is supported. Defaults to `*`.
 * `enabled` - (Optional) The state of the external integration. Defaults to `true`.
 
 ## Import

--- a/website/docs/r/integration_ecr.html.markdown
+++ b/website/docs/r/integration_ecr.html.markdown
@@ -1,0 +1,52 @@
+---
+layout: "lacework"
+page_title: "Lacework: lacework_integration_ecr"
+description: |-
+  Create and manage ECR integrations
+---
+
+# lacework\_integration\_ecr
+
+Use this resource to integrate an Amazon Container Registry (ECR) with Lacework to assess, identify,
+and report vulnerabilities found in the operating system software packages in a Docker container
+image.
+
+~> **Note:** Assessing a retagged ECR image is not supported because ECR does not consider it a new image and does not create a new entry. To assess a retagged image, use on-demand assessment through the Lacework CLI/API. For more information, see the [container vulnerability section in the Lacework CLI documentation](https://github.com/lacework/go-sdk/wiki/CLI-Documentation#container-vulnerability-assessments).
+
+## Example Usage
+
+```hcl
+resource "lacework_integration_ecr" "example" {
+  name              = "ERC Example"
+  registry_domain   = "YourAWSAccount.dkr.ecr.YourRegion.amazonaws.com"
+  access_key_id     = "AWS123abcAccessKeyID"
+  secret_access_key = "AWS123abc123abcSecretAccessKey0000000000"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The Lacework container registry integration name.
+* `registry_domain` - (Required) The Amazon Container Registry (ECR) domain in the format `YourAWSAccount.dkr.ecr.YourRegion.amazonaws.com`, where `YourAWSAcount` is the AWS account number for the AWS IAM user that has a role with permissions to access the ECR and `YourRegion` is your AWS region such as `us-west-2`.
+* `access_key_id` - (Required) The AWS access key ID for an AWS IAM user that has a role with permissions to access the Amazon Container Registry (ECR).
+* `secret_access_key` - (Required) The AWS secret key for the specified AWS access key.
+* `limit_by_tag` - (Optional) An image tag to limit the assessment of images with matching tag. If you specify `limit_by_tag` and `limit_by_label` limits, they function as an `AND`. Supported field input are `mytext*mytext`, `mytext`, `mytext*`, or `mytext`. Only one `*` wildcard is supported. Defaults to `*`.
+* `limit_by_label` - (Optional) An image label to limit the assessment of images with matching label. If you specify `limit_by_tag` and `limit_by_label` limits, they function as an `AND`. Supported field input are `mytext*mytext`, `mytext`, `mytext*`, or `mytext`. Only one `*` wildcard is supported. Defaults to `*`.
+* `limit_by_repos` - (Optional) A comma-separated list of repositories to assess. (without spaces recommended)
+* `limit_num_imgs` - (Optional) The maximum number of newest container images to assess per repository. Must be one of `5`, `10`, or `15`. Defaults to `5`.
+* `enabled` - (Optional) The state of the external integration. Defaults to `true`.
+
+## Import
+
+A Lacework ECR integration can be imported using a `INT_GUID`, e.g.
+
+```
+$ terraform import lacework_integration_ecr.example EXAMPLE_1234BAE1E42182964D23973F44CFEA3C4AB63B99E9A1EC5
+```
+-> **Note:** To retreive the `INT_GUID` from existing integrations in your account, use the
+	Lacework CLI command `lacework integration list`. To install this tool follow
+	[this documentation](https://github.com/lacework/go-sdk/wiki/CLI-Documentation#installation).
+
+

--- a/website/docs/r/integration_ecr.html.markdown
+++ b/website/docs/r/integration_ecr.html.markdown
@@ -11,7 +11,7 @@ Use this resource to integrate an Amazon Container Registry (ECR) with Lacework 
 and report vulnerabilities found in the operating system software packages in a Docker container
 image.
 
-~> **Note:** Assessing a retagged ECR image is not supported because ECR does not consider it a new image and does not create a new entry. To assess a retagged image, use on-demand assessment through the Lacework CLI/API. For more information, see the [container vulnerability section in the Lacework CLI documentation](https://github.com/lacework/go-sdk/wiki/CLI-Documentation#container-vulnerability-assessments).
+~> **Note:** Assessing a retagged ECR image is not supported because ECR does not consider it a new image and does not create a new entry. To assess a retagged image, use on-demand assessment through the Lacework CLI. For more information, see the [container vulnerability section in the Lacework CLI documentation](https://github.com/lacework/go-sdk/wiki/CLI-Documentation#container-vulnerability-assessments).
 
 ## Example Usage
 
@@ -28,7 +28,7 @@ resource "lacework_integration_ecr" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The Lacework container registry integration name.
+* `name` - (Required) The ECR integration name.
 * `registry_domain` - (Required) The Amazon Container Registry (ECR) domain in the format `YourAWSAccount.dkr.ecr.YourRegion.amazonaws.com`, where `YourAWSAcount` is the AWS account number for the AWS IAM user that has a role with permissions to access the ECR and `YourRegion` is your AWS region such as `us-west-2`.
 * `access_key_id` - (Required) The AWS access key ID for an AWS IAM user that has a role with permissions to access the Amazon Container Registry (ECR).
 * `secret_access_key` - (Required) The AWS secret key for the specified AWS access key.

--- a/website/docs/r/integration_gcp_at.html.markdown
+++ b/website/docs/r/integration_gcp_at.html.markdown
@@ -30,7 +30,7 @@ resource "lacework_integration_gcp_at" "account_abc" {
 
 The following arguments are supported:
 
-* `name` - (Required) The Lacework GCP Audit Trail integration name.
+* `name` - (Required) The GCP Audit Trail integration name.
 * `resource_id` - (Required) The organization or project ID.
 * `subscription` - (Required) The subscription queue name.
 * `credentials` - (Required) The credentials needed by the integration. See [Credentials](#credentials) below for details.

--- a/website/docs/r/integration_gcp_cfg.html.markdown
+++ b/website/docs/r/integration_gcp_cfg.html.markdown
@@ -28,7 +28,7 @@ resource "lacework_integration_gcp_cfg" "account_abc" {
 
 The following arguments are supported:
 
-* `name` - (Required) The Lacework GCP Config integration name.
+* `name` - (Required) The GCP Config integration name.
 * `resource_id` - (Required) The organization or project ID.
 * `credentials` - (Required) The credentials needed by the integration. See [Credentials](#credentials) below for details.
 * `resource_level` - (Optional) The integration level. Must be one of `PROJECT` or `ORGANIZATION`. Defaults to `PROJECT`.

--- a/website/docs/r/integration_gcr.html.markdown
+++ b/website/docs/r/integration_gcr.html.markdown
@@ -30,7 +30,7 @@ resource "lacework_integration_gcr" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The Lacework container registry integration name.
+* `name` - (Required) The GCR integration name.
 * `registry_domain` - (Required) The GCR domain, which specifies the location where you store the images. Supported domains are `gcr.io`, `us.gcr.io`, `eu.gcr.io`, or `asia.gcr.io`.
 * `credentials` - (Required) The credentials needed by the integration. See [Credentials](#credentials) below for details.
 * `limit_by_tag` - (Optional) An image tag to limit the assessment of images with matching tag. If you specify `limit_by_tag` and `limit_by_label` limits, they function as an `AND`. Supported field input are `mytext*mytext`, `mytext`, `mytext*`, or `mytext`. Only one `*` wildcard is supported. Defaults to `*`.

--- a/website/docs/r/integration_gcr.html.markdown
+++ b/website/docs/r/integration_gcr.html.markdown
@@ -1,0 +1,63 @@
+---
+layout: "lacework"
+page_title: "Lacework: lacework_integration_gcr"
+description: |-
+  Create and manage GCR integrations
+---
+
+# lacework\_integration\_gcr
+
+Use this resource to integrate a Google Container Registry (GCR) with Lacework to assess, identify,
+and report vulnerabilities found in the operating system software packages in a Docker container
+image.
+
+## Example Usage
+
+```hcl
+resource "lacework_integration_gcr" "example" {
+  name            = "GRC Example"
+  registry_domain = "gcr.io"
+  credentials {
+    client_id      = "123456789012345678900"
+    client_email   = "email@abc-project-name.iam.gserviceaccount.com"
+    private_key_id = "1234abcd1234abcd1234abcd1234abcd1234abcd"
+    private_key    = "-----BEGIN PRIVATE KEY-----\n ... -----END PRIVATE KEY-----\n"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The Lacework container registry integration name.
+* `registry_domain` - (Required) The GCR domain, which specifies the location where you store the images. Supported domains are `gcr.io`, `us.gcr.io`, `eu.gcr.io`, or `asia.gcr.io`.
+* `credentials` - (Required) The credentials needed by the integration. See [Credentials](#credentials) below for details.
+* `limit_by_tag` - (Optional) An image tag to limit the assessment of images with matching tag. If you specify `limit_by_tag` and `limit_by_label` limits, they function as an `AND`. Supported field input are `mytext*mytext`, `mytext`, `mytext*`, or `mytext`. Only one `*` wildcard is supported. Defaults to `*`.
+* `limit_by_label` - (Optional) An image label to limit the assessment of images with matching label. If you specify `limit_by_tag` and `limit_by_label` limits, they function as an `AND`. Supported field input are `mytext*mytext`, `mytext`, `mytext*`, or `mytext`. Only one `*` wildcard is supported. Defaults to `*`.
+* `limit_by_repos` - (Optional) A comma-separated list of repositories to assess. (without spaces recommended)
+* `limit_num_imgs` - (Optional) The maximum number of newest container images to assess per repository. Must be one of `5`, `10`, or `15`. Defaults to `5`.
+* `enabled` - (Optional) The state of the external integration. Defaults to `true`.
+
+### Credentials
+
+`credentials` supports the following arguments:
+
+* `client_id` - (Required) The service account client ID.
+* `client_email` - (Required) The service account client email.
+* `private_key_id` - (Required) The service account private key ID.
+* `private_key` - (Required) The service account private key.
+
+~> **Note:** The service account used for this integration requires the `storage.objectViewer` role for access to the Google project that contains the Google Container Registry (GCR). The role can be granted at the project level or the bucket level. If granting the role at the bucket level, you must grant the role to the default bucket called `artifacts.[YourProjectID].appspot.com`. In addition, the client must have access to the Google Container Registry API and billing must be enabled.
+
+## Import
+
+A Lacework GCR integration can be imported using a `INT_GUID`, e.g.
+
+```
+$ terraform import lacework_integration_gcr.example EXAMPLE_1234BAE1E42182964D23973F44CFEA3C4AB63B99E9A1EC5
+```
+-> **Note:** To retreive the `INT_GUID` from existing integrations in your account, use the
+	Lacework CLI command `lacework integration list`. To install this tool follow
+	[this documentation](https://github.com/lacework/go-sdk/wiki/CLI-Documentation#installation).
+

--- a/website/lacework.erb
+++ b/website/lacework.erb
@@ -53,6 +53,9 @@
               <a href="/docs/providers/lacework/r/integration_docker_hub.html">lacework_integration_docker_hub</a>
             </li>
             <li>
+              <a href="/docs/providers/lacework/r/integration_docker_v2.html">lacework_integration_docker_v2</a>
+            </li>
+            <li>
               <a href="/docs/providers/lacework/r/integration_gcp_cfg.html">lacework_integration_gcp_cfg</a>
             </li>
             <li>

--- a/website/lacework.erb
+++ b/website/lacework.erb
@@ -56,6 +56,9 @@
               <a href="/docs/providers/lacework/r/integration_docker_v2.html">lacework_integration_docker_v2</a>
             </li>
             <li>
+              <a href="/docs/providers/lacework/r/integration_ecr.html">lacework_integration_ecr</a>
+            </li>
+            <li>
               <a href="/docs/providers/lacework/r/integration_gcp_cfg.html">lacework_integration_gcp_cfg</a>
             </li>
             <li>

--- a/website/lacework.erb
+++ b/website/lacework.erb
@@ -61,6 +61,9 @@
             <li>
               <a href="/docs/providers/lacework/r/integration_gcp_at.html">lacework_integration_gcp_at</a>
             </li>
+            <li>
+              <a href="/docs/providers/lacework/r/integration_gcr.html">lacework_integration_gcr</a>
+            </li>
           </ul>
         </li>
       </ul>

--- a/website/lacework.erb
+++ b/website/lacework.erb
@@ -11,64 +11,105 @@
         </li>
 
         <li>
-          <a href="#">Data Sources</a>
-          <ul class="nav nav-visible">
-            <li>
-              <a href="/docs/providers/lacework/d/api_token.html">lacework_api_token</a>
-            </li>
-          </ul>
+        <a href="#">Alert Channels</a>
+        <ul class="nav">
+          <li>
+            <a href="#">Resources</a>
+            <ul class="nav nav-auto-expand">
+
+              <li>
+                <a href="/docs/providers/lacework/r/alert_channel_aws_cloudwatch.html">lacework_alert_channel_aws_cloudwatch</a>
+              </li>
+              <li>
+                <a href="/docs/providers/lacework/r/alert_channel_jira_cloud.html">lacework_alert_channel_jira_cloud</a>
+              </li>
+              <li>
+                <a href="/docs/providers/lacework/r/alert_channel_jira_server.html">lacework_alert_channel_jira_server</a>
+              </li>
+              <li>
+                <a href="/docs/providers/lacework/r/alert_channel_pagerduty.html">lacework_alert_channel_pagerduty</a>
+              </li>
+              <li>
+                <a href="/docs/providers/lacework/r/alert_channel_slack.html">lacework_alert_channel_slack</a>
+              </li>
+
+            </ul>
+          </li>
+        </ul>
         </li>
 
         <li>
-          <a href="#">Resources</a>
-          <ul class="nav nav-visible">
-            <li>
-              <a href="/docs/providers/lacework/r/alert_channel_aws_cloudwatch.html">lacework_alert_channel_aws_cloudwatch</a>
-            </li>
-            <li>
-              <a href="/docs/providers/lacework/r/alert_channel_jira_cloud.html">lacework_alert_channel_jira_cloud</a>
-            </li>
-            <li>
-              <a href="/docs/providers/lacework/r/alert_channel_jira_server.html">lacework_alert_channel_jira_server</a>
-            </li>
-            <li>
-              <a href="/docs/providers/lacework/r/alert_channel_pagerduty.html">lacework_alert_channel_pagerduty</a>
-            </li>
-            <li>
-              <a href="/docs/providers/lacework/r/alert_channel_slack.html">lacework_alert_channel_slack</a>
-            </li>
-            <li>
-              <a href="/docs/providers/lacework/r/integration_aws_cfg.html">lacework_integration_aws_cfg</a>
-            </li>
-            <li>
-              <a href="/docs/providers/lacework/r/integration_aws_ct.html">lacework_integration_aws_ct</a>
-            </li>
-            <li>
-              <a href="/docs/providers/lacework/r/integration_azure_cfg.html">lacework_integration_azure_cfg</a>
-            </li>
-            <li>
-              <a href="/docs/providers/lacework/r/integration_azure_al.html">lacework_integration_azure_al</a>
-            </li>
-            <li>
-              <a href="/docs/providers/lacework/r/integration_docker_hub.html">lacework_integration_docker_hub</a>
-            </li>
-            <li>
-              <a href="/docs/providers/lacework/r/integration_docker_v2.html">lacework_integration_docker_v2</a>
-            </li>
-            <li>
-              <a href="/docs/providers/lacework/r/integration_ecr.html">lacework_integration_ecr</a>
-            </li>
-            <li>
-              <a href="/docs/providers/lacework/r/integration_gcp_cfg.html">lacework_integration_gcp_cfg</a>
-            </li>
-            <li>
-              <a href="/docs/providers/lacework/r/integration_gcp_at.html">lacework_integration_gcp_at</a>
-            </li>
-            <li>
-              <a href="/docs/providers/lacework/r/integration_gcr.html">lacework_integration_gcr</a>
-            </li>
-          </ul>
+        <a href="#">Cloud Account Integrations</a>
+        <ul class="nav">
+          <li>
+            <a href="#">Resources</a>
+            <ul class="nav nav-auto-expand">
+
+              <li>
+                <a href="/docs/providers/lacework/r/integration_aws_cfg.html">lacework_integration_aws_cfg</a>
+              </li>
+              <li>
+                <a href="/docs/providers/lacework/r/integration_aws_ct.html">lacework_integration_aws_ct</a>
+              </li>
+              <li>
+                <a href="/docs/providers/lacework/r/integration_azure_cfg.html">lacework_integration_azure_cfg</a>
+              </li>
+              <li>
+                <a href="/docs/providers/lacework/r/integration_azure_al.html">lacework_integration_azure_al</a>
+              </li>
+              <li>
+                <a href="/docs/providers/lacework/r/integration_gcp_cfg.html">lacework_integration_gcp_cfg</a>
+              </li>
+              <li>
+                <a href="/docs/providers/lacework/r/integration_gcp_at.html">lacework_integration_gcp_at</a>
+              </li>
+
+            </ul>
+          </li>
+        </ul>
         </li>
+
+        <li>
+        <a href="#">Container Registry Integrations</a>
+        <ul class="nav">
+          <li>
+            <a href="#">Resources</a>
+            <ul class="nav nav-auto-expand">
+
+              <li>
+                <a href="/docs/providers/lacework/r/integration_docker_hub.html">lacework_integration_docker_hub</a>
+              </li>
+              <li>
+                <a href="/docs/providers/lacework/r/integration_docker_v2.html">lacework_integration_docker_v2</a>
+              </li>
+              <li>
+                <a href="/docs/providers/lacework/r/integration_ecr.html">lacework_integration_ecr</a>
+              </li>
+              <li>
+                <a href="/docs/providers/lacework/r/integration_gcr.html">lacework_integration_gcr</a>
+              </li>
+
+            </ul>
+          </li>
+        </ul>
+        </li>
+
+        <li>
+        <a href="#">Other Resources</a>
+        <ul class="nav">
+          <li>
+            <a href="#">Data Sources</a>
+            <ul class="nav nav-auto-expand">
+
+              <li>
+                <a href="/docs/providers/lacework/d/api_token.html">lacework_api_token</a>
+              </li>
+
+            </ul>
+          </li>
+        </ul>
+        </li>
+
       </ul>
     </div>
   <% end %>


### PR DESCRIPTION
# New Resources!
![tenor-227129839](https://user-images.githubusercontent.com/5712253/92740600-1938e300-f33b-11ea-86e3-28d4efc94991.gif)

## Docker V2 Registry
```hcl
resource "lacework_integration_docker_v2" "jfrog" {
  name = "My Docker V2 Registry"
  registry_domain = "my-dockerv2.jfrog.io"
  username = "my-user"
  password = "a-secret-password"
  ssl = true
}
```

## Google Container Registry (GCR)
```hcl
resource "lacework_integration_gcr" "example" {
  name            = "GRC Example"
  registry_domain = "gcr.io"
  credentials {
    client_id      = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
    private_key_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
    client_email   = "email@some-project-name.iam.gserviceaccount.com"
    private_key    = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
  }
}
```

## Amazon Container Registry (ECR)
```hcl
resource "lacework_integration_ecr" "example" {
  name              = "ERC Example"
  registry_domain   = "YourAWSAccount.dkr.ecr.YourRegion.amazonaws.com"
  access_key_id     = "AWS123abcAccessKeyID"
  secret_access_key = "AWS123abc123abcSecretAccessKey0000000000"
}
```

Closes to https://github.com/terraform-providers/terraform-provider-lacework/issues/21

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>